### PR TITLE
avoid tweet blank

### DIFF
--- a/app/models/tweet.rb
+++ b/app/models/tweet.rb
@@ -7,7 +7,7 @@ class Tweet < ApplicationRecord
 
   MAX_IMAGES_COUNT = 3
   validate :images_count_limit
-  validates :content, presence: true 
+  validates :content, {presence: true, length: {maximum: 140}}
 
   private
 

--- a/app/models/tweet.rb
+++ b/app/models/tweet.rb
@@ -3,11 +3,11 @@ class Tweet < ApplicationRecord
   has_many :comments, dependent: :destroy
   has_many_attached :images, dependent: :destroy
   belongs_to :user
-  enum publicity: {everybody: 0, only_followers: 1, only_me: 2}
+  enum publicity: {　everybody: 0, only_followers: 1, only_me: 2　}
 
   MAX_IMAGES_COUNT = 3
   validate :images_count_limit
-  validates :content, {presence: true, length: {maximum: 140}}
+  validates :content, {　presence: true, length: {maximum: 140}　}
 
   private
 

--- a/app/models/tweet.rb
+++ b/app/models/tweet.rb
@@ -7,12 +7,11 @@ class Tweet < ApplicationRecord
   MAX_IMAGES_COUNT = 3
 
   validate :images_count_limit
+  validates :content, presence: true 
 
   private
 
     def images_count_limit
       errors.add(:base, "写真は#{MAX_IMAGES_COUNT}枚まで") if self.images.count > MAX_IMAGES_COUNT
     end
-
-
 end

--- a/app/views/tweets/_form.html.erb
+++ b/app/views/tweets/_form.html.erb
@@ -2,7 +2,8 @@
 
   <div class="field">
     <%= form.label :content %>
-    <%= form.text_area :content, required: true%>
+    <%= tweet.errors.full_messages.to_sentence %>
+    <%= form.text_area :content, required: true %>
   </div>
 
   <div class="field">

--- a/app/views/tweets/_form.html.erb
+++ b/app/views/tweets/_form.html.erb
@@ -2,7 +2,7 @@
 
   <div class="field">
     <%= form.label :content %>
-    <%= form.text_area :content %>
+    <%= form.text_area :content, required: true%>
   </div>
 
   <div class="field">


### PR DESCRIPTION
## 背景
新規Tweet作成の際に、空文字列による入力を防ぎたい。

## やったこと
Tweetモデルに、Validationを追加